### PR TITLE
Small bug fix in commands.py / parse_shell()

### DIFF
--- a/herokuapp/commands.py
+++ b/herokuapp/commands.py
@@ -19,7 +19,7 @@ def parse_shell(lines):
     """ Parse config variables from the lines """
 
     # If there are no config variables, return an empty dict
-    if RE_PARSE_SHELL.search(str(lines)):
+    if not RE_PARSE_SHELL.search(str(lines)):
         return dict()
     return dict(
         line.strip().split("=", 1)


### PR DESCRIPTION
parse_shell() currently returns an empty dict when the regular expression gets a match - it should probably do the opposite (with the current version, apps cannot read any Heroku environment variables on my machine).