### PR TITLE
commands.py / parse_shell(): properly parse environment variables with spaces

### DIFF
--- a/herokuapp/commands.py
+++ b/herokuapp/commands.py
@@ -24,7 +24,7 @@ def parse_shell(lines):
     return dict(
         line.strip().split("=", 1)
         for line
-        in lines.split()
+        in lines
     )
 
 


### PR DESCRIPTION
I ran into another small bug in parse_shell(): the current version splits lines on spaces before doing the key/value split on '='. This causes problems with environment variables that have one or more spaces in them (I use New Relic and I have "NEW_RELIC_APP_NAME=Website (Production)", for instance).

Since the lines are already properly separated by newlines, I dont think the split on whitespace is necessary - I removed it.