### PR TITLE
heroku: replace addons:add with addons:create

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ You can provision a starter package with Heroku Postgres using the following Her
 
 ::
 
-    $ heroku addons:add heroku-postgresql:dev
+    $ heroku addons:create heroku-postgresql:dev
 
 
 Static file hosting - Amazon S3
@@ -164,7 +164,7 @@ You can provision a starter package with SendGrid using the following Heroku com
 
 ::
 
-    $ heroku addons:add sendgrid:starter
+    $ heroku addons:create sendgrid:starter
 
 
 Optimizing compiled slug size


### PR DESCRIPTION
Thanks for your guide!

I was running the Heroku bits and found this:

```
$ heroku addons:add heroku-postgresql
WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.
```

This PR replaces `addons:add` with `addons:create`.
